### PR TITLE
Handle multiline blocks properly

### DIFF
--- a/lib/liquid.ex
+++ b/lib/liquid.ex
@@ -41,7 +41,7 @@ defmodule Liquid do
     do:
       ~r/#{tag_start()}\s*(?<tag>.*?)\s*#{tag_end()}|#{variable_start()}\s*(?<variable>.*?)\s*#{
         variable_end()
-      }/m
+      }/ms
 
   def template_parser, do: ~r/#{partial_template_parser()}|#{any_starting_tag()}/ms
 

--- a/test/liquid/block_test.exs
+++ b/test/liquid/block_test.exs
@@ -80,4 +80,15 @@ defmodule Liquid.BlockTest do
     template = Liquid.Template.parse("{% testtag %}")
     assert [%Liquid.Tag{name: :testtag}] = template.root.nodelist
   end
+
+  test "with multiline block" do
+    template = Liquid.Template.parse("""
+      {% include 'foo',
+        foo: bar,
+        bar: 'baz',
+        baz: foo
+      %}\
+      """)
+      assert 1 == Enum.count(template.root.nodelist)
+  end
 end


### PR DESCRIPTION
Closes #2

Output after the fix:

```
iex(3)> str = """
...(3)>       {% include 'foo',
...(3)>         foo: bar,
...(3)>         bar: 'baz',
...(3)>         baz: foo
...(3)>       %}\
...(3)>       """
"{% include 'foo',\n  foo: bar,\n  bar: 'baz',\n  baz: foo\n%}"
iex(4)> Liquid.Template.parse(str)
%Liquid.Template{
  blocks: [],
  errors: [],
  presets: %{},
  root: %Liquid.Block{
    blank: false,
    condition: nil,
    elselist: [],
    iterator: [],
    markup: nil,
    name: :document,
    nodelist: [
      %Liquid.Tag{
        attributes: %{
          "bar" => %Liquid.Variable{
            filters: [],
            literal: "baz",
            name: "'baz'",
            parts: []
          },
          "baz" => %Liquid.Variable{
            filters: [],
            literal: nil,
            name: "foo",
            parts: ["foo"]
          },
          "foo" => %Liquid.Variable{
            filters: [],
            literal: nil,
            name: "bar",
            parts: ["bar"]
          }
        },
        blank: false,
        markup: "'foo',\n  foo: bar,\n  bar: 'baz',\n  baz: foo",
        name: :include,
        parts: [
          name: %Liquid.Variable{
            filters: [],
            literal: "foo",
            name: "'foo'",
            parts: []
          }
        ]
      }
    ],
    parts: [],
    strict: true
  }
}
```