### PR TITLE
Force inline of regexp returning functions

### DIFF
--- a/lib/liquid.ex
+++ b/lib/liquid.ex
@@ -10,6 +10,31 @@ defmodule Liquid do
 
   def stop, do: {:ok, "stopped"}
 
+  @compile {:inline, argument_separator: 0}
+  @compile {:inline, filter_argument_separator: 0}
+  @compile {:inline, filter_quoted_string: 0}
+  @compile {:inline, filter_quoted_fragment: 0}
+  @compile {:inline, filter_arguments: 0}
+  @compile {:inline, single_quote: 0}
+  @compile {:inline, double_quote: 0}
+  @compile {:inline, quote_matcher: 0}
+  @compile {:inline, variable_start: 0}
+  @compile {:inline, variable_end: 0}
+  @compile {:inline, variable_incomplete_end: 0}
+  @compile {:inline, tag_start: 0}
+  @compile {:inline, tag_end: 0}
+  @compile {:inline, any_starting_tag: 0}
+  @compile {:inline, invalid_expression: 0}
+  @compile {:inline, tokenizer: 0}
+  @compile {:inline, parser: 0}
+  @compile {:inline, template_parser: 0}
+  @compile {:inline, partial_template_parser: 0}
+  @compile {:inline, quoted_string: 0}
+  @compile {:inline, quoted_fragment: 0}
+  @compile {:inline, tag_attributes: 0}
+  @compile {:inline, variable_parser: 0}
+  @compile {:inline, filter_parser: 0}
+
   def argument_separator, do: ","
   def filter_argument_separator, do: ":"
   def filter_quoted_string, do: "\"[^\"]*\"|'[^']*'"

--- a/lib/liquid/include.ex
+++ b/lib/liquid/include.ex
@@ -5,6 +5,7 @@ defmodule Liquid.Include do
   alias Liquid.Variable, as: Variable
   alias Liquid.FileSystem, as: FileSystem
 
+  @compile {:inline, syntax: 0}
   def syntax,
     do: ~r/(#{Liquid.quoted_fragment()}+)(\s+(?:with|for)\s+(#{Liquid.quoted_fragment()}+))?/
 

--- a/lib/liquid/tags/assign.ex
+++ b/lib/liquid/tags/assign.ex
@@ -3,6 +3,7 @@ defmodule Liquid.Assign do
   alias Liquid.Tag
   alias Liquid.Context
 
+  @compile {:inline, syntax: 0}
   def syntax, do: ~r/([\w\-]+)\s*=\s*(.*)\s*/
 
   def parse(%Tag{} = tag, %Liquid.Template{} = template), do: {%{tag | blank: true}, template}

--- a/lib/liquid/tags/case.ex
+++ b/lib/liquid/tags/case.ex
@@ -5,8 +5,10 @@ defmodule Liquid.Case do
   alias Liquid.Variable
   alias Liquid.Condition
 
+  @compile {:inline, syntax: 0}
   def syntax, do: ~r/(#{Liquid.quoted_fragment()})/
 
+  @compile {:inline, when_syntax: 0}
   def when_syntax,
     do: ~r/(#{Liquid.quoted_fragment()})(?:(?:\s+or\s+|\s*\,\s*)(#{Liquid.quoted_fragment()}.*))?/
 

--- a/lib/liquid/tags/for_else.ex
+++ b/lib/liquid/tags/for_else.ex
@@ -62,6 +62,7 @@ defmodule Liquid.ForElse do
               forloop: %{}
   end
 
+  @compile {:inline, syntax: 0}
   def syntax, do: ~r/(\w+)\s+in\s+(#{Liquid.quoted_fragment()}+)\s*(reversed)?/
 
   def parse(%Block{nodelist: nodelist} = block, %Liquid.Template{} = t) do

--- a/lib/liquid/tags/if_else.ex
+++ b/lib/liquid/tags/if_else.ex
@@ -15,9 +15,11 @@ defmodule Liquid.IfElse do
   alias Liquid.Tag
   alias Liquid.Template
 
+  @compile {:inline, syntax: 0}
   def syntax,
     do: ~r/(#{Liquid.quoted_fragment()})\s*([=!<>a-z_]+)?\s*(#{Liquid.quoted_fragment()})?/
 
+  @compile {:inline, expressions_and_operators: 0}
   def expressions_and_operators do
     ~r/(?:\b(?:\s?and\s?|\s?or\s?)\b|(?:\s*(?!\b(?:\s?and\s?|\s?or\s?)\b)(?:#{
       Liquid.quoted_fragment()

--- a/lib/liquid/tags/raw.ex
+++ b/lib/liquid/tags/raw.ex
@@ -3,6 +3,7 @@ defmodule Liquid.Raw do
   alias Liquid.Render
   alias Liquid.Block
 
+  @compile {:inline, full_token_possibly_invalid: 0}
   def full_token_possibly_invalid,
     do: ~r/\A(.*)#{Liquid.tag_start()}\s*(\w+)\s*(.*)?#{Liquid.tag_end()}\z/m
 

--- a/lib/liquid/tags/table_row.ex
+++ b/lib/liquid/tags/table_row.ex
@@ -21,6 +21,7 @@ defmodule Liquid.TableRow do
               forloop: %{}
   end
 
+  @compile {:inline, syntax: 0}
   def syntax, do: ~r/(\w+)\s+in\s+(#{Liquid.quoted_fragment()}+)/
 
   @doc """


### PR DESCRIPTION
This PR forces elixir compiler to inline functions/0 which return regexp fragments.

It doesn't change anything else in behaviour, other than performance (and a little bit harder to read stack traces - which doesn't matter here).

The median time of request for an internal project utilizing Liquid (a lot of it) in synthetic tests decreases by 16%, while 99th percentile decreased by 26%.